### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-inquiry [![Build Status](https://secure.travis-ci.org/tasks/inquiry.png)](http://travis-ci.org/tasks/inquiry) [![Version](https://pypip.in/v/inquiry/badge.png)](https://github.com/tasks/inquiry) [![codecov.io](https://codecov.io/github/tasks/inquiry/coverage.png)](https://codecov.io/github/tasks/inquiry)
+inquiry [![Build Status](https://secure.travis-ci.org/tasks/inquiry.png)](http://travis-ci.org/tasks/inquiry) [![Version](https://img.shields.io/pypi/v/inquiry.svg)](https://github.com/tasks/inquiry) [![codecov.io](https://codecov.io/github/tasks/inquiry/coverage.png)](https://codecov.io/github/tasks/inquiry)
 -------
 
 `pip install inquiry`


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20inquiry))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `inquiry`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.